### PR TITLE
Fix documentation for /api/v1/users/current.json endpoint

### DIFF
--- a/endpoints/users.md
+++ b/endpoints/users.md
@@ -16,7 +16,6 @@ Returns details about the authenticated user.
 {
   "user": {
     "id": 1,
-    "email": "bob@example.com",
     "name": "Bob",
     "created_at": "2024-01-17T01:45:09Z",
     "updated_at": "2024-06-11T21:11:16Z"


### PR DESCRIPTION
Closes #16 by removing the `email` key in the response of `GET /api/v1/users/current.json`